### PR TITLE
Removes global search

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use Phpsa\FilamentAuthentication\Resources\UserResource as AuthUserResource;
+
+class UserResource extends AuthUserResource
+{
+
+    protected static ?string $recordTitleAttribute = NULL;
+
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use Filament\Facades\Filament;
 use Illuminate\Support\ServiceProvider;
 use App\Filament\Resources\FlagResource;
 use App\Filament\Resources\ToolResource;
+use App\Filament\Resources\UserResource;
 use Filament\Navigation\NavigationGroup;
 use App\Filament\Resources\ScaleResource;
 use App\Filament\Resources\TopicResource;
@@ -27,7 +28,6 @@ use App\Filament\Resources\MetricPropertyResource;
 use App\Filament\Resources\DiscussionPointResource;
 use App\Filament\Resources\CollectionMethodResource;
 use Phpsa\FilamentAuthentication\Resources\RoleResource;
-use Phpsa\FilamentAuthentication\Resources\UserResource;
 use Phpsa\FilamentAuthentication\Resources\PermissionResource;
 
 class AppServiceProvider extends ServiceProvider

--- a/config/filament-authentication.php
+++ b/config/filament-authentication.php
@@ -7,7 +7,7 @@ return [
         'Permission' => \Spatie\Permission\Models\Permission::class,
     ],
     'resources'     => [
-        'UserResource'       => \Phpsa\FilamentAuthentication\Resources\UserResource::class,
+        'UserResource'       => App\Filament\Resources\UserResource::class,
         'RoleResource'       => \Phpsa\FilamentAuthentication\Resources\RoleResource::class,
         'PermissionResource' => \Phpsa\FilamentAuthentication\Resources\PermissionResource::class,
     ],


### PR DESCRIPTION
This PR removes the global search by:
- extending the UserResource from filament-authentication to set $recordTitleAttribute as null (the only resource that had it set)