### PR TITLE
Add Widgets

### DIFF
--- a/app/Filament/Widgets/StatsWidget.php
+++ b/app/Filament/Widgets/StatsWidget.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Tool;
+use App\Models\Scale;
+use App\Models\Theme;
+use App\Models\Metric;
+use App\Models\Country;
+use App\Models\Dimension;
+use App\Models\Framework;
+use App\Models\Geography;
+use App\Models\MetricUser;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+
+class StatsWidget extends BaseWidget
+{
+    protected function getStats(): array
+    {
+        $metricCount = Stat::make('Total Metrics', Metric::count());
+        $themeCount = Stat::make('Total Themes', Theme::count());
+        $dimensionCount = Stat::make('Total Dimensions', Dimension::count());
+        $geographyCount = Stat::make('Total Geographies', Geography::count());
+        $countryCount = Stat::make('Total Countries', Country::count());
+        $toolCount = Stat::make('Total Tools', Tool::count());
+        $frameworkCount = Stat::make('Total Frameworks', Framework::count());
+        $scaleCount = Stat::make('Total Scales', Scale::count());
+        $metricUserCount = Stat::make('Total Metric Users', MetricUser::count());
+
+        return [$metricCount, $themeCount, $dimensionCount, $geographyCount, $countryCount, $toolCount, $frameworkCount, $scaleCount, $metricUserCount];
+    }
+}

--- a/app/Filament/Widgets/StatsWidget.php
+++ b/app/Filament/Widgets/StatsWidget.php
@@ -21,13 +21,12 @@ class StatsWidget extends BaseWidget
         $metricCount = Stat::make('Total Metrics', Metric::count());
         $themeCount = Stat::make('Total Themes', Theme::count());
         $dimensionCount = Stat::make('Total Dimensions', Dimension::count());
-        $geographyCount = Stat::make('Total Geographies', Geography::count());
-        $countryCount = Stat::make('Total Countries', Country::count());
+        $countryCount = Stat::make('Total Countries', Geography::count() + Country::count());
         $toolCount = Stat::make('Total Tools', Tool::count());
         $frameworkCount = Stat::make('Total Frameworks', Framework::count());
         $scaleCount = Stat::make('Total Scales', Scale::count());
         $metricUserCount = Stat::make('Total Metric Users', MetricUser::count());
 
-        return [$metricCount, $themeCount, $dimensionCount, $geographyCount, $countryCount, $toolCount, $frameworkCount, $scaleCount, $metricUserCount];
+        return [$metricCount, $themeCount, $dimensionCount, $countryCount, $toolCount, $frameworkCount, $scaleCount, $metricUserCount];
     }
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -37,10 +37,6 @@ class AppPanelProvider extends PanelProvider
                 Pages\Dashboard::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
-            ->widgets([
-                Widgets\AccountWidget::class,
-                Widgets\FilamentInfoWidget::class,
-            ])
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,


### PR DESCRIPTION
This PR is submitted to fix #42 

It contains below changes:
1. Add new widgets to show total number of entities in dashboard page
2. Remove two default widgets

---

Screen shot

![image](https://github.com/stats4sd/tpp-metrics-library/assets/86968034/9761794a-0365-4fcd-9fcb-52ac83b3a2e5)
