### PR TITLE
Deduplication of relationships

### DIFF
--- a/app/Console/Commands/OneTimeScripts/AddMetricRelationships.php
+++ b/app/Console/Commands/OneTimeScripts/AddMetricRelationships.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\OneTimeScripts;
 
 use Illuminate\Console\Command;
 

--- a/app/Console/Commands/OneTimeScripts/ImportCsvMetricEvaluations.php
+++ b/app/Console/Commands/OneTimeScripts/ImportCsvMetricEvaluations.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\OneTimeScripts;
 
 use App\Models\Dimension;
 use App\Models\Metric;

--- a/app/Console/Commands/OneTimeScripts/ImportCsvToolEvaluations.php
+++ b/app/Console/Commands/OneTimeScripts/ImportCsvToolEvaluations.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\OneTimeScripts;
 
 use App\Models\Country;
 use App\Models\DataCollection;

--- a/app/Console/Commands/OneTimeScripts/RemoveDuplicateLinkTableEntries.php
+++ b/app/Console/Commands/OneTimeScripts/RemoveDuplicateLinkTableEntries.php
@@ -44,7 +44,7 @@ class RemoveDuplicateLinkTableEntries extends Command
                 $this->deduplicateRelationship($metric, 'units');
                 $this->deduplicateRelationship($metric, 'metricUsers');
                 $this->deduplicateRelationship($metric, 'geographies');
-                $this->deduplicateRelationship($metric, 'scales');
+                $this->deduplicateRelationship($metric, 'themes');
 
                 // referencables are all unique for metrics;
 

--- a/app/Console/Commands/OneTimeScripts/RemoveDuplicateLinkTableEntries.php
+++ b/app/Console/Commands/OneTimeScripts/RemoveDuplicateLinkTableEntries.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands\OneTimeScripts;
+
+use App\Models\CollectionMethod;
+use App\Models\Metric;
+use Illuminate\Console\Command;
+
+class RemoveDuplicateLinkTableEntries extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:remove-duplicate-link-table-entries';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Searches through all link tables and ensures that there are no model entries linked together more than once.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // Pretty sure this is only for metric_ relationships.
+        $metrics = Metric::all();
+
+        $metrics->each(function (Metric $metric) {
+
+            if ($metric->collectionMethods()->count() > 0) {
+
+                $this->comment('----');
+                $this->info('metric ID' . $metric->id);
+
+                $collectionMethods = $metric->collectionMethods->mapWithKeys(function(CollectionMethod $collectionMethod) {
+                    return [$collectionMethod->id => [
+                        'relation_notes' => $collectionMethod->pivot->relation_notes,
+                        'needs_review' => $collectionMethod->pivot->needs_review
+                    ]];
+                });
+
+                $metric->collectionMethods()->detach($metric->collectionMethods->pluck('id')->toArray());
+                $metric->collectionMethods()->sync($collectionMethods);
+
+            }
+
+            // $metric->collectionMethods()->sync($metric->collectionMethods->unique('id')->pluck('id'));
+        });
+
+
+    }
+}

--- a/app/Models/Metric.php
+++ b/app/Models/Metric.php
@@ -3,14 +3,14 @@
 namespace App\Models;
 
 use App\Models\Traits\GetRelationships;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Metric extends Model
 {
@@ -223,7 +223,7 @@ class Metric extends Model
     public function themes(): BelongsToMany
     {
         return $this->belongsToMany(Theme::class, 'metric_theme')
-            ->withPivot('relation_notes', 'unreviewd_import', 'needs_review')
+            ->withPivot('relation_notes', 'unreviewed_import', 'needs_review')
             ->withTimestamps();
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,7 +5,6 @@ namespace App\Providers;
 use App\Filament\Resources\MethodResource;
 use App\Filament\Resources\MetricPropertyResource;
 use App\Filament\Resources\PropertyTypeResource;
-use Filament\Forms\Components\Textarea;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -27,7 +26,60 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        // set text area default number of rows across entire app
-        Textarea::configureUsing(fn($config) => $config->rows(6));
+
+
+//        FilamentEnvironmentIndicator::configureUsing(function (FilamentEnvironmentIndicator $indicator) {
+//            $indicator->visible = fn() => auth()->user()?->hasRole('admin');
+//        }, isImportant: true);
+
+        // Filament::navigation(function (NavigationBuilder $builder): NavigationBuilder {
+        //     return $builder
+        //         ->item(...MetricResource::getNavigationItems())
+        //         ->item(...PropertyResource::getNavigationItems())
+        //         ->groups([
+        //             NavigationGroup::make('Review Tools')
+        //                 ->items([
+        //                     ...DiscussionPointResource::getNavigationItems(),
+        //                     ...FlagResource::getNavigationItems(),
+        //                     ...FeedbackResource::getNavigationItems(),
+        //                 ]),
+        //             NavigationGroup::make('Topics')
+        //                 ->items([
+        //                     ...TopicResource::getNavigationItems(),
+        //                     ...DimensionResource::getNavigationItems(),
+        //                     ...SubDimensionResource::getNavigationItems(),
+        //                 ]),
+        //             NavigationGroup::make('Scales, Users, Use Cases')
+        //                 ->items([
+        //                     ...ScaleResource::getNavigationItems(),
+        //                     ...MetricUserResource::getNavigationItems(),
+        //                 ]),
+        //             NavigationGroup::make('Tools, Methods + Frameworks')
+        //                 ->items([
+        //                     ...ToolResource::getNavigationItems(),
+        //                     ...CollectionMethodResource::getNavigationItems(),
+        //                     ...FrameworkResource::getNavigationItems(),
+        //                 ]),
+        //             NavigationGroup::make('Systems and Geographies')
+        //                 ->items([
+        //                     ...FarmingSystemResource::getNavigationItems(),
+        //                     ...GeographyResource::getNavigationItems(),
+        //                 ]),
+        //             NavigationGroup::make('References')
+        //                 ->items([
+        //                     ...ReferenceResource::getNavigationItems(),
+        //                 ]),
+        //             NavigationGroup::make('Imports')
+        //                 ->items([
+        //                     ...ImportResource::getNavigationItems(),
+        //                 ]),
+        //             NavigationGroup::make('Users and Roles')
+        //             ->items([
+        //                 ...UserResource::getNavigationItems(),
+        //                 ...RoleResource::getNavigationItems(),
+        //                 ...PermissionResource::getNavigationItems(),
+        //             ]),
+        //         ]);
+        // });
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Filament\Resources\MethodResource;
 use App\Filament\Resources\MetricPropertyResource;
 use App\Filament\Resources\PropertyTypeResource;
+use Filament\Forms\Components\Textarea;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -26,60 +27,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-
-
-//        FilamentEnvironmentIndicator::configureUsing(function (FilamentEnvironmentIndicator $indicator) {
-//            $indicator->visible = fn() => auth()->user()?->hasRole('admin');
-//        }, isImportant: true);
-
-        // Filament::navigation(function (NavigationBuilder $builder): NavigationBuilder {
-        //     return $builder
-        //         ->item(...MetricResource::getNavigationItems())
-        //         ->item(...PropertyResource::getNavigationItems())
-        //         ->groups([
-        //             NavigationGroup::make('Review Tools')
-        //                 ->items([
-        //                     ...DiscussionPointResource::getNavigationItems(),
-        //                     ...FlagResource::getNavigationItems(),
-        //                     ...FeedbackResource::getNavigationItems(),
-        //                 ]),
-        //             NavigationGroup::make('Topics')
-        //                 ->items([
-        //                     ...TopicResource::getNavigationItems(),
-        //                     ...DimensionResource::getNavigationItems(),
-        //                     ...SubDimensionResource::getNavigationItems(),
-        //                 ]),
-        //             NavigationGroup::make('Scales, Users, Use Cases')
-        //                 ->items([
-        //                     ...ScaleResource::getNavigationItems(),
-        //                     ...MetricUserResource::getNavigationItems(),
-        //                 ]),
-        //             NavigationGroup::make('Tools, Methods + Frameworks')
-        //                 ->items([
-        //                     ...ToolResource::getNavigationItems(),
-        //                     ...CollectionMethodResource::getNavigationItems(),
-        //                     ...FrameworkResource::getNavigationItems(),
-        //                 ]),
-        //             NavigationGroup::make('Systems and Geographies')
-        //                 ->items([
-        //                     ...FarmingSystemResource::getNavigationItems(),
-        //                     ...GeographyResource::getNavigationItems(),
-        //                 ]),
-        //             NavigationGroup::make('References')
-        //                 ->items([
-        //                     ...ReferenceResource::getNavigationItems(),
-        //                 ]),
-        //             NavigationGroup::make('Imports')
-        //                 ->items([
-        //                     ...ImportResource::getNavigationItems(),
-        //                 ]),
-        //             NavigationGroup::make('Users and Roles')
-        //             ->items([
-        //                 ...UserResource::getNavigationItems(),
-        //                 ...RoleResource::getNavigationItems(),
-        //                 ...PermissionResource::getNavigationItems(),
-        //             ]),
-        //         ]);
-        // });
+        // set text area default number of rows across entire app
+        Textarea::configureUsing(fn($config) => $config->rows(6));
     }
 }


### PR DESCRIPTION
Small PR - fixes #41. 

Adds a one-time command to deduplicate entries in the metrics_ relationship pivot tables. Run `php artisan app:remove-duplicate-link-table-entries` to deduplicate entries in metrics pivot tables. 

Also moved all our 'one-time' commands to a dedicated folder. 

### Notes (SQL queries to check)

Testing with metrics_collection_method: 

```

select
    count(id),
    metric_id,
    collection_method_id
from metric_collection_method
group by metric_id, collection_method_id
order by count(id) desc; -- 11,797 unique entries.

select count(id) from metric_collection_method; 
-- BEFORE running command: 12286 entries;
-- AFTER running command: 11797 entries;

```

Approach used doesn't keep pivot values from any duplicates, but there are no duplicated entries with different pivot values:

```
-- All the below show 0 entries except where indicated.

select * from metric_collection_method where relation_notes is not null; -- 0 entries.
select * from metric_dimension where relation_notes is not null;
select * from metric_farming_system where relation_notes is not null;
select * from metric_framework where relation_notes is not null;
    -- framework_id 1; metric_id 1 - only 1 entry.

select * from metric_geography where relation_notes is not null;
select * from metric_metric where relation_notes is not null;
select * from metric_metric_user where relation_notes is not null;
-- metric id 1; metric_user_id 1 - only 1 entry.

select * from metric_parent_child where relation_notes is not null;
select * from metric_property_options where relation_notes is not null;
select * from metric_scale where relation_notes is not null;
  -- 3 entries; scale_id = 2 is duplicated, but the relation_notes are identical. 

select * from metric_scale where metric_id = 1 and scale_id in (2,3,4);
select * from metric_sub_dimension where relation_notes is not null;
select * from metric_theme where relation_notes is not null;
select * from metric_tool where relation_notes is not null;
select * from metric_topic where relation_notes is not null;
select * from metric_unit where relation_notes is not null;
```